### PR TITLE
docstring cleanup and slight formatting/refactoring

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,4 +2,4 @@
 
 `pelitk`:
 - [`lex`](LEX.md)
-- [`conc`]CONC.md)
+- [`conc`](CONC.md)

--- a/pelitk/conc.py
+++ b/pelitk/conc.py
@@ -3,8 +3,8 @@
 __version__ = '0.1'
 __author__ = 'Na-Rae Han, Ben Naismith'
 
-
 # Series of subfunctions for final 'concordance' function
+
 
 def get_node(tok_text, node, num, pos=False):
     """
@@ -21,20 +21,23 @@ def get_node(tok_text, node, num, pos=False):
             Set to True if the tok_text is a list of tuples
     """
     if pos:
-        padding = [('','')] * num              # non-word padding, in the specified size
+        padding = [('', '')] * num  # non-word padding, in the specified size
         padded = padding + tok_text + padding  # pad in front and back
         outlist = []
         for i in range(len(padded)):
             if padded[i] == node:
-                outlist.append(([x[0] for x in padded[i-num:i]], padded[i][0], [x[0] for x in padded[i+1:i+1+num]]))
+                outlist.append(
+                    ([x[0] for x in padded[i - num:i]], padded[i][0],
+                     [x[0] for x in padded[i + 1:i + 1 + num]]))
     else:
-        padding = [('')] * num                 # non-word padding, in the specified size
+        padding = [('')] * num  # non-word padding, in the specified size
         padded = padding + tok_text + padding  # pad in front and back
         outlist = []
         for i in range(len(padded)):
             if padded[i] == node:
-                outlist.append((padded[i-num:i], padded[i], padded[i+1:i+1+num]))
-    return outlist        
+                outlist.append(
+                    (padded[i - num:i], padded[i], padded[i + 1:i + 1 + num]))
+    return outlist
 
 
 def flatten(outlist):
@@ -50,7 +53,6 @@ def flatten(outlist):
     return flatlist
 
 
-
 def prettify(flatlist):
     """
     Improve the appearance of the flatlist (output of flattn function) to look like a typical
@@ -59,8 +61,7 @@ def prettify(flatlist):
     Args:
         flatlist : the output of the function flatten
     """
-    return ['{:>40} {:^12} {:<40}'.format(x,y,z) for (x,y,z) in flatlist]
-
+    return ['{:>40} {:^12} {:<40}'.format(x, y, z) for (x, y, z) in flatlist]
 
 
 def concordance(tok_text, node, num, pos=False, pretty=False):
@@ -82,7 +83,7 @@ def concordance(tok_text, node, num, pos=False, pretty=False):
     """
     if not pretty:
         if pos:
-            return flatten(get_node(tok_text, node, num,pos=True))
+            return flatten(get_node(tok_text, node, num, pos=True))
         else:
             return flatten(get_node(tok_text, node, num))
     else:

--- a/pelitk/lex.py
+++ b/pelitk/lex.py
@@ -81,9 +81,10 @@ def adv_guiraud(text, freq_list='NGSL', custom_list=None,
     else:
         if freq_list not in FILE_MAP:
             raise KeyError(
-                """Please specify an appropriate frequency list with
-                the custom_list arg or set freq_list to one of {}
-                """.format(FILE_MAP.keys()))
+                "Please specify set freq_list to one of {}".format(
+                    ", ".join(FILE_MAP.keys()))
+            )
+
         common_types = _load_wordlist(freq_list)
     # Include supplementary
     if supplementary:
@@ -104,9 +105,10 @@ def adv_guiraud(text, freq_list='NGSL', custom_list=None,
         # already tokens?
         tokens = text
 
-    if not len(tokens) == 0:
+    if len(tokens) == 0:
         return 0
 
+    # TODO: do we really need to support a list of list of tokens?
     if isinstance(tokens[0], list):
         res = []
         # tokens is a list of lists of tokens

--- a/pelitk/lex.py
+++ b/pelitk/lex.py
@@ -68,8 +68,9 @@ def adv_guiraud(text, freq_list='NGSL', custom_list=None,
             common types to ignore for AG instead of freq_list.
         spellcheck (bool): boolean flag to ignore misspelled words
             checked via enable1 wordlist + 'i' + 'a'
-        supplementary: Include NGSL supplementary vocabulary in addition to
-            specified list
+        supplementary (bool): Include NGSL supplementary vocabulary in
+            addition to specified frequency list
+        lemmas (bool): whether to lemmatize before adding to advanced type count
     Returns:
         Calculated AG
     """
@@ -109,6 +110,7 @@ def adv_guiraud(text, freq_list='NGSL', custom_list=None,
         return 0
 
     # TODO: do we really need to support a list of list of tokens?
+    # the below if/else blocks have a lot of duplicated code between them
     if isinstance(tokens[0], list):
         res = []
         # tokens is a list of lists of tokens

--- a/pelitk/lex.py
+++ b/pelitk/lex.py
@@ -17,8 +17,9 @@ FILE_MAP = {
     'NGSL': resource_filename('pelitk', 'data/wordlists/ngsl_2k.txt'),
     'PSL3': resource_filename('pelitk', 'data/wordlists/psl3.txt'),
     'ENABLE1': resource_filename('pelitk', 'data/wordlists/enable1.txt'),
-    'SUPP': resource_filename('pelitk', 'data/wordlists/supplementary.txt')                                ),
+    'SUPP': resource_filename('pelitk', 'data/wordlists/supplementary.txt')
 }
+
 # lookup table created from NGSL and spaCy word lists
 LOOKUP = pickle.loads(pkgutil.get_data('pelitk', 'data/lemmatizer.pkl'))
 
@@ -30,34 +31,45 @@ def _load_wordlist(key):
 
 
 def re_tokenize(text):
-    """
-    Regular expression tokenizer. Lowercases input and removes symbols/digits.
+    """ regex tokenizer that lowercases input and removes symbols/digits.
 
     Args:
-        text: An input string
+        text (str): An input string
     Returns:
         List of tokens found in input string
     """
     return re.findall(r"[A-Za-z]+", text.lower())
 
 
-def adv_guiraud(text, freq_list='NGSL', custom_list=None,
-                spellcheck=True, supplementary=True, lemmas=False):
-    """
-    Calculates advanced guiraud: advanced types / sqrt(number of tokens)
-    By default, uses NGSL top 2k words as frequency list
-    custom_list is a custom list of common types for frequency list
+def spellcheck_filter(tokens):
+    """ Remove tokens whose lemmas do not appear in wordnet.synsets()
 
     Args:
-        text: Input string to calculate AG for
-        freq_list: string specifying which freq list to use. Must be one
-                   of {'NGSL','PELIC', 'SUPP'}
-        custom_list: if not None, used instead of freq_list (can pass own list
-                     of strings containing common types to ignore for AG
-        spellcheck: Boolean flag to ignore misspelled words (rough spellcheck
-                    with enable1 + 'i' + 'a')
+        tokens (List[str]): input list of tokens
+
+    Returns:
+        filtered list of tokens
+    """
+    return [t for t in tokens if wordnet.synsets(LOOKUP.get(t, t))]
+
+
+def adv_guiraud(text, freq_list='NGSL', custom_list=None,
+                spellcheck=True, supplementary=True, lemmas=False):
+    """ Calculates advanced guiraud: advanced types / sqrt(number of tokens)
+
+    By default, uses NGSL top 2k words as frequency list of common types to
+    ignore.
+
+    Args:
+        text (str): Input string to calculate AG for
+        freq_list (str): string specifying which freq list to use. Must be one
+            of {'NGSL','PELIC', 'SUPP'}
+        custom_list (List[str]): if not None, used as a list of
+            common types to ignore for AG instead of freq_list.
+        spellcheck (bool): boolean flag to ignore misspelled words
+            checked via enable1 wordlist + 'i' + 'a'
         supplementary: Include NGSL supplementary vocabulary in addition to
-                       specified list
+            specified list
     Returns:
         Calculated AG
     """
@@ -68,25 +80,31 @@ def adv_guiraud(text, freq_list='NGSL', custom_list=None,
         common_types = set(custom_list)
     else:
         if freq_list not in FILE_MAP:
-            raise KeyError("""Please specify an appropriate frequency list with
-                              custom_list or set freq_list to one of NGSL, PSL, 
-                              SUPP.""")
+            raise KeyError(
+                """Please specify an appropriate frequency list with
+                the custom_list arg or set freq_list to one of {}
+                """.format(FILE_MAP.keys()))
         common_types = _load_wordlist(freq_list)
     # Include supplementary
     if supplementary:
         common_types = common_types.union(_load_wordlist('SUPP'))
 
+    # TODO: can we use the same spellchecking everywhere?
+    # here we use enable1, elsewhere we use wordnet.synsets()
     dictionary = _load_wordlist('ENABLE1')
     dictionary.add('i')
     dictionary.add('a')
 
+    # TODO: we inconsistently allow str or list input to AG, but
+    # only str to the other methods (voc-D, mtld, etc)
+    # we should pick one and keep it consistent
     if isinstance(text, str):
         tokens = re_tokenize(text)
     else:
         # already tokens?
         tokens = text
 
-    if len(tokens) == 0:
+    if not len(tokens) == 0:
         return 0
 
     if isinstance(tokens[0], list):
@@ -150,10 +168,22 @@ def vocd(text, spellcheck=False, length_range=(35, 50),
     https://metacpan.org/pod/release/AXANTHOS/Lingua-Diversity-0.07/lib/Lingua/Diversity/VOCD.pm
 
     Args:
-        text:
+        text (str): input text string to compute voc-D measure for
+        spellcheck (bool): if True, exclude words whose lemmas
+            are not in nltk.wordnet.synsets
+        length_range ((int, int)): tuple of the range of sample sizes
+            to use in computing voc-D
+        num_subsamples (int): number of subsamples to take per sample
+            size
+        num_trials (int): number of trials to average over
+
+    Returns:
+        avg_D (float): estimated D value
     """
-    tokens = [x for x in re_tokenize(
-        text) if not spellcheck or wordnet.synsets(LOOKUP.get(x, x))]
+    tokens = [x for x in re_tokenize(text)]
+    if spellcheck:
+        tokens = spellcheck_filter(tokens)
+
     if len(tokens) < length_range[1]:
         raise ValueError("""Sample size greater than population!. Either reduce
                             the bounds of length_range or try a different
@@ -187,8 +217,10 @@ def mtld(text, spellcheck=False, factor_size=0.72):
     """
     Implements the Measure of Textual Lexical Diversity (MTLD)
     """
-    tokens = [x for x in re_tokenize(
-        text) if not spellcheck or wordnet.synsets(LOOKUP.get(x, x))]
+    tokens = [x for x in re_tokenize(text)]
+    if spellcheck:
+        tokens = spellcheck_filter(tokens)
+
     forward_factor_count = _mtld_pass(tokens, factor_size)
     backward_factor_count = _mtld_pass(tokens[::-1], factor_size)
     if forward_factor_count == 0 or backward_factor_count == 0:
@@ -222,8 +254,9 @@ def maas(text, spellcheck=False):
     """
     Compute the a^2 Maas index.
     """
-    tokens = [x for x in re_tokenize(
-        text) if not spellcheck or wordnet.synsets(LOOKUP.get(x, x))]
+    tokens = [x for x in re_tokenize(text)]
+    if spellcheck:
+        tokens = spellcheck_filter(tokens)
     num_tokens = len(tokens)
     num_types = len(set(tokens))
     a_squared = math.log(num_tokens) - \

--- a/pelitk/lex.py
+++ b/pelitk/lex.py
@@ -53,8 +53,12 @@ def spellcheck_filter(tokens):
     return [t for t in tokens if wordnet.synsets(LOOKUP.get(t, t))]
 
 
-def adv_guiraud(text, freq_list='NGSL', custom_list=None,
-                spellcheck=True, supplementary=True, lemmas=False):
+def adv_guiraud(text,
+                freq_list='NGSL',
+                custom_list=None,
+                spellcheck=True,
+                supplementary=True,
+                lemmas=False):
     """ Calculates advanced guiraud: advanced types / sqrt(number of tokens)
 
     By default, uses NGSL top 2k words as frequency list of common types to
@@ -81,10 +85,8 @@ def adv_guiraud(text, freq_list='NGSL', custom_list=None,
         common_types = set(custom_list)
     else:
         if freq_list not in FILE_MAP:
-            raise KeyError(
-                "Please specify set freq_list to one of {}".format(
-                    ", ".join(FILE_MAP.keys()))
-            )
+            raise KeyError("Please specify set freq_list to one of {}".format(
+                ", ".join(FILE_MAP.keys())))
 
         common_types = _load_wordlist(freq_list)
     # Include supplementary
@@ -164,8 +166,11 @@ def _vocd_eq(N, D):
     return D / N * (np.sqrt(1 + 2 * N / D) - 1)
 
 
-def vocd(text, spellcheck=False, length_range=(35, 50),
-         num_subsamples=100, num_trials=3):
+def vocd(text,
+         spellcheck=False,
+         length_range=(35, 50),
+         num_subsamples=100,
+         num_trials=3):
     """
     Calculate 'D' with voc-D method (approximation of HD-D)
     Inspired by

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from setuptools import setup, find_packages
 import sys
 from os import path
 
-import nltk
 
 here = path.abspath(path.dirname(__file__))
 
@@ -29,5 +28,6 @@ setup(
     include_package_data=True
 )
 
-if 'install' in sys.argv:
+if 'install' in sys.argv or 'develop' in sys.argv:
+    import nltk
     nltk.download('wordnet')

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
 import sys
 from os import path
+from setuptools import setup, find_packages
 
 
 here = path.abspath(path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import sys
 from os import path
 from setuptools import setup, find_packages
 
-
 here = path.abspath(path.dirname(__file__))
 
 with open('README.md') as f:
@@ -13,20 +12,18 @@ with open('README.md') as f:
 with open('LICENSE') as f:
     license = f.read()
 
-setup(
-    name='pelitk',
-    version='0.1.4',
-    description='Package for processing text, especially texts in PELIC',
-    long_description=readme,
-    authors='Daniel Zheng, Na-Rae Han, Ben Naismith',
-    author_email='naraehan@pitt.edu',
-    url='https://github.com/ELI-Data-Mining-Group/pelitk',
-    license=license,
-    install_requires=['nltk', 'scipy', 'numpy'],
-    packages=find_packages(exclude=('tests', 'docs')),
-    package_data={'pelitk': ['data/wordlists/*.txt', 'data/*.pkl']},
-    include_package_data=True
-)
+setup(name='pelitk',
+      version='0.1.4',
+      description='Package for processing text, especially texts in PELIC',
+      long_description=readme,
+      authors='Daniel Zheng, Na-Rae Han, Ben Naismith',
+      author_email='naraehan@pitt.edu',
+      url='https://github.com/ELI-Data-Mining-Group/pelitk',
+      license=license,
+      install_requires=['nltk', 'scipy', 'numpy'],
+      packages=find_packages(exclude=('tests', 'docs')),
+      package_data={'pelitk': ['data/wordlists/*.txt', 'data/*.pkl']},
+      include_package_data=True)
 
 if 'install' in sys.argv or 'develop' in sys.argv:
     import nltk


### PR DESCRIPTION
Hey guys, it has been quite a while since I looked at `pelitk` but happy to see it is still being worked on!

This is just a brief PR making some slight improvements to docstrings and formatting. 
- Ran [yapf](https://github.com/google/yapf) on all python files to fix some formatting issues
- Added types and cleaned up some docstrings in `lex.py`
- fixed typo in `docs/README.md`
- fixed import ordering in `setup.py` and moved `import nltk` to right before `nltk.download('wordnet')`, since otherwise the import will fail bc nltk is not yet installed at that point (we did not catch this before because we all had nltk installed before installing pelitk)

I have also started a list of issues at https://github.com/ELI-Data-Mining-Group/pelitk/issues . I included the couple `TODO` items in the `adv_guiraud` function as issues as well. Please take a look when you have a chance! Thanks!