### PR TITLE
[lex] standardize input format

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ Calculates Advanced Guiraud (AG):
 
 ```python
 >>> from pelitk import lex
->>> print('AG:', lex.adv_guiraud('hi this is a test string'))
+>>> tokens = lex.re_tokenize('hi this is a test string')
+>>> print('AG:', lex.adv_guiraud(tokens))
 AG: 0.8164965809277261
 ```
-
 <br>
 
 **`vocd`**  
@@ -106,7 +106,8 @@ Calculates vocD:
   - the default requires a minimum text length of 35 words (the default number of sub-samples), though this can be optionally adjusted
 
 ```python
-print('D:', lex.vocd('hi this is a test string that needs to be at least thirty five words long in order for the calculations to work, as such, I will continue to add a few more words here in order to meet the minimum requirements of this particular function. And a few more'))
+>>> tokens = lex.re_tokenize('hi this is a test string that needs to be at least thirty five words long in order for the calculations to work, as such, I will continue to add a few more words here in order to meet the minimum requirements of this particular function. And a few more')
+>>> print('D:', lex.vocd(tokens))
 D: 62.09673137243385
 ```
 
@@ -119,7 +120,8 @@ Calculates Type-Token_Ratio (TTR):
   - practical to calculate but sensitive to text length (shorter texts have higher TTR)
 
 ```python
-print('TTR:', lex.ttr('hi this is a test string with the words test and string occurring twice'))
+>>> tokens = lex.re_tokenize('hi this is a test string with the words test and string occurring twice')
+>>> print('TTR:', lex.ttr(tokens))
 TTR: 0.8571428571428571
 ```
 
@@ -129,7 +131,8 @@ Calculates Measure of Textual Lexical Diversity (MTLD):
   - formula = complex sequential analysis of samples, generating a score based on TTR scores in the samples.
 
 ```python
-print('MTLD:', lex.mtld('hi this is a test string with the words test and string occuring twice'))
+>>> tokens = lex.re_tokenize('hi this is a test string with the words test and string occuring twice')
+>>> print('MTLD:', lex.mtld(tokens))
 MTLD: 27.439999999999994
 ```
 
@@ -141,7 +144,8 @@ Calculates Maas (log 2):
   - formula = TTR with log correction
 
 ```python
-print('Maas:', lex.maas('hi this is a test string with the words test and string occuring twice'))
+>>> tokens = lex.re_tokenize('hi this is a test string with the words test and string occuring twice')
+>>> print('Maas:', lex.maas(tokens))
 Maas: 2.28226753070723
 ```
 <br>

--- a/docs/LEX.md
+++ b/docs/LEX.md
@@ -24,27 +24,6 @@ lex.re_tokenize('Hi how are you?')
 ['hi', 'how', 'are', 'you']
 ```
 
-### **lemmatize(tokens)**
-
-#### **Parameters**:
-  - `tokens`: List of tokens | Example: `['hi', 'how', 'are', 'you']`
-
-#### **Returns**:
-List of lemmas
-
-#### **Example**:
-
-###### **Code**:
-```python
-lex.lemmatize(['hi', 'how', 'are', 'you'])
-
-```
-
-###### **Output**
-```python
-['hello', 'how', 'be', 'you']
-```
-
 ### **ttr(tokens)**
 Calculate Type-Token ratio on a list of tokens. 
 
@@ -66,10 +45,10 @@ lex.ttr(['words', 'should', 'go', 'here', 'more', 'words'])
 0.8333333333333334
 ```
 
-### **adv_guiraud(text, freq_list='NGSL', custom_list=None, spellcheck=True)**
+### **adv_guiraud(tokens, freq_list='NGSL', custom_list=None, spellcheck=True)**
 
 #### **Parameters**:
-  - `text`: Input string | Example: `'Hi how are you doing today?'`
+  - `tokens`: Input list of tokens | Example: `['Hi', 'how', 'are', 'you', 'doing', 'today']`
   - `freq_list` (optional, defaults to `'NGSL'`): Specify list of 2K common types to use for AG. Options include `'NGSL', 'PET', 'PELIC'`. | Example: `'PET'`
   - `custom_list` (optional, defaults to `None`): Specify a custom list of common types to use for AG as a list of lemmas. | Example: `['the', 'be', .....]`
   - `spellcheck` (optional, defaults to `True`): Specify whether or not advanced types should be spell-checked using `wordnet.synsets()`. | Example: `False`
@@ -81,7 +60,8 @@ Calculated AG lexical diversity index: `advanced types / sqrt(tokens)`
 #### **Example**:
 ###### **Code**:
 ```python
-lex.adv_guiraud('Hi how are you doing today?')
+tokens = lex.re_tokenize('Hi how are you doing today?')
+lex.adv_guiraud(tokens)
 ```
 
 ###### **Output**
@@ -89,10 +69,10 @@ lex.adv_guiraud('Hi how are you doing today?')
 0.4082482904638631
 ```
 
-### **vocd(text, spellcheck=False, length_range=(35,50), num_subsamples=100, num_trials=3)**
+### **vocd(tokens, spellcheck=False, length_range=(35,50), num_subsamples=100, num_trials=3)**
 Implemented as described [here](http://www.leeds.ac.uk/educol/documents/00001541.htm)
 #### **Parameters**:
-  - `text`: Input string | Example: `'Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, “ and what is the use of a book,” thought Alice, “ without pictures or conversations ?” So she was considering in her own mind, (as well as she could, for the hot day made her feel very sleepy and stupid,) whether the pleasure of making a daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly a white rabbit with pink eyes ran close by her.'`
+  - `tokens`: Input list of tokens | Example: `lex.re_tokenize('Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, “ and what is the use of a book,” thought Alice, “ without pictures or conversations ?” So she was considering in her own mind, (as well as she could, for the hot day made her feel very sleepy and stupid,) whether the pleasure of making a daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly a white rabbit with pink eyes ran close by her.')`
   - `spellcheck` (optional, defaults to `True`): Specify whether or not advanced types should be spell-checked using `wordnet.synsets()`. | Example: `False`
   - `length_range` (optional, defaults to `(35, 50)`): A tuple with the lower and upper bounds of random sample size for vocd. | Example: `(20, 60)`
   - `num_subsamples` (optional, defaults to `100`): A positive integer specifying how many times to randomly sample the text. | Example: `200`
@@ -105,17 +85,18 @@ Estimated "D" parameter for the voc-D lexical diversity index
 ###### **Code**:
 ```python
 text = 'Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, “ and what is the use of a book,” thought Alice, “ without pictures or conversations ?” So she was considering in her own mind, (as well as she could, for the hot day made her feel very sleepy and stupid,) whether the pleasure of making a daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly a white rabbit with pink eyes ran close by her.'
-lex.vocd(text)
+tokens = lex.re_tokenize(text)
+lex.vocd(tokens)
 ```
 
 ###### **Output**
 ```python
 83.757961976435737
 ```
-### **mtld(text, spellcheck=True, factor_size=0.72)**
+### **mtld(tokens , spellcheck=True, factor_size=0.72)**
 Measure of Textual Lexical Diversity implemented as described [here](https://link.springer.com/content/pdf/10.3758%2FBRM.42.2.381.pdf)
 #### **Parameters**:
-  - `text`: Input string | Example: `'Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, “ and what is the use of a book,” thought Alice, “ without pictures or conversations ?” So she was considering in her own mind, (as well as she could, for the hot day made her feel very sleepy and stupid,) whether the pleasure of making a daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly a white rabbit with pink eyes ran close by her.'`
+  - `tokens`: list of tokens | Example: `lex.re_tokenize('Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, “ and what is the use of a book,” thought Alice, “ without pictures or conversations ?” So she was considering in her own mind, (as well as she could, for the hot day made her feel very sleepy and stupid,) whether the pleasure of making a daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly a white rabbit with pink eyes ran close by her.'`
   - `spellcheck` (optional, defaults to `False`): Specify whether or not advanced types should be spell-checked using `wordnet.synsets()`. | Example: `True`
   - `factor_size` (optional, defaults to `0.72`): Specify the TTR cutoff for adding to factor counts. | Example: `0.6`
 
@@ -127,6 +108,7 @@ Calculated MTLD value
 ###### **Code**:
 ```python
 text = 'Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, “ and what is the use of a book,” thought Alice, “ without pictures or conversations ?” So she was considering in her own mind, (as well as she could, for the hot day made her feel very sleepy and stupid,) whether the pleasure of making a daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly a white rabbit with pink eyes ran close by her.'
+tokens = lex.re_tokenize(text)
 lex.mtld(text)
 ```
 

--- a/tests/test_lex.py
+++ b/tests/test_lex.py
@@ -10,7 +10,6 @@ LONG_TOKENS = lex.re_tokenize(LONG_TEXT)
 random.seed(0)
 
 def test_re_tokenize():
-    assert False
     input_str = 'hi this is a test string'
     expected_tokens = ['hi', 'this', 'is', 'a', 'test', 'string']
 

--- a/tests/test_lex.py
+++ b/tests/test_lex.py
@@ -6,6 +6,7 @@ import pytest
 from pelitk import lex
 
 LONG_TEXT = 'Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, “ and what is the use of a book,” thought Alice, “ without pictures or conversations ?” So she was considering in her own mind, (as well as she could, for the hot day made her feel very sleepy and stupid,) whether the pleasure of making a daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly a white rabbit with pink eyes ran close by her.'
+LONG_TOKENS = lex.re_tokenize(LONG_TEXT)
 random.seed(0)
 
 def test_re_tokenize():
@@ -25,23 +26,26 @@ def test_re_tokenize():
 
 def test_adv_guiraud():
     input_str = 'hi this is a test string'
+    tokens = lex.re_tokenize(input_str)
     # expect 'test' and 'string' to be advanced types
-    assert pytest.approx(lex.adv_guiraud(input_str), 2 / math.sqrt(6))
+    assert pytest.approx(lex.adv_guiraud(tokens), 2 / math.sqrt(6))
 
     input_str_zero_ag = 'this is the'
-    assert lex.adv_guiraud(input_str_zero_ag) == 0
+    tokens_str_zero_ag = lex.re_tokenize(input_str_zero_ag)
+    assert lex.adv_guiraud(tokens_str_zero_ag) == 0
 
     input_str_spell = 'this is a missspellingg'
+    tokens_str_spell = lex.re_tokenize(input_str_spell)
     # test w/ spellcheck (misspelling is removed)
     assert lex.adv_guiraud(input_str_spell) == 0
     # test w/o spellcheck
-    assert lex.adv_guiraud(input_str_spell, spellcheck=False) == 1 / math.sqrt(4)
+    assert lex.adv_guiraud(tokens_str_spell, spellcheck=False) == 1 / math.sqrt(4)
 
 
 def test_vocd():
-    assert pytest.approx(lex.vocd(LONG_TEXT)) == 83.399341
+    assert pytest.approx(lex.vocd(LONG_TOKENS)) == 83.399341
 
-    assert pytest.approx(lex.vocd(LONG_TEXT, spellcheck=True)) == 132.035466
+    assert pytest.approx(lex.vocd(LONG_TOKENS, spellcheck=True)) == 132.035466
 
 
 def test_ttr():
@@ -55,11 +59,11 @@ def test_ttr():
 
 
 def test_mtld():
-    assert pytest.approx(lex.mtld(LONG_TEXT)) == 78.277031
+    assert pytest.approx(lex.mtld(LONG_TOKENS)) == 78.277031
 
 
 def test_maas():
-    assert pytest.approx(lex.maas(LONG_TEXT)) == 4.5336033
-    assert pytest.approx(lex.maas(LONG_TEXT, spellcheck=True)) == 4.125937
+    assert pytest.approx(lex.maas(LONG_TOKENS)) == 4.5336033
+    assert pytest.approx(lex.maas(LONG_TOKENS, spellcheck=True)) == 4.125937
 
 

--- a/tests/test_lex.py
+++ b/tests/test_lex.py
@@ -10,6 +10,7 @@ LONG_TOKENS = lex.re_tokenize(LONG_TEXT)
 random.seed(0)
 
 def test_re_tokenize():
+    assert False
     input_str = 'hi this is a test string'
     expected_tokens = ['hi', 'this', 'is', 'a', 'test', 'string']
 


### PR DESCRIPTION
This resolves https://github.com/ELI-Data-Mining-Group/pelitk/issues/4. btw i don't think we should close issues until they are resolved, or abandoned as in the case of https://github.com/ELI-Data-Mining-Group/pelitk/issues/1. This way things won't fall thru the cracks or get forgotten about.

This PR updates all the functions to take tokens as input, and significantly shortens the AG function as a result :grinning: 

I updated tests and docs as well, and deleted a block about `lex.lemmatize()` because we removed that function long ago. 

Also, when I was updating the relevant docs I had to update every function twice, because it appears we have duplicated the examples from `docs/LEX.md` in the main `README.md`. I assume this was done for convenience, but would it be ok to just have these in one place?
If we want them in the main README.md, then I think we should delete examples from `docs/LEX.md`, or vice versa. It is difficult enough to remember to update documentation when changing code, so if we can avoid documentation duplication that would be great. Thoughts on this? @bnaismith @naraehan 